### PR TITLE
Proxy protocol support on listening socket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	github.com/pires/go-proxyproto v0.8.0
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kK
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQscQm2s=
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
+github.com/pires/go-proxyproto v0.8.0 h1:5unRmEAPbHXHuLjDg01CxJWf91cw3lKHc/0xzKpXEe0=
+github.com/pires/go-proxyproto v0.8.0/go.mod h1:iknsfgnH8EkjrMeMyvfKByp9TiBZCKZM0jx2xmKqnVY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/SenseUnit/dumbproxy/forward"
 	"github.com/SenseUnit/dumbproxy/handler"
 	clog "github.com/SenseUnit/dumbproxy/log"
+	proxyproto "github.com/pires/go-proxyproto"
 )
 
 var (
@@ -255,6 +256,7 @@ type CLIArgs struct {
 	jsAccessFilter            string
 	jsAccessFilterInstances   int
 	jsProxyRouterInstances    int
+	proxyproto                bool
 }
 
 func parse_args() CLIArgs {
@@ -350,6 +352,7 @@ func parse_args() CLIArgs {
 		args.proxy = append(args.proxy, proxyArg{false, p})
 		return nil
 	})
+	flag.BoolVar(&args.proxyproto, "proxyproto", false, "listen proxy protocol")
 	flag.Parse()
 	args.positionalArgs = flag.Args()
 	return args
@@ -556,6 +559,11 @@ func run() int {
 			return 3
 		}
 		listener = newListener
+	}
+
+	if args.proxyproto {
+		mainLogger.Info("Listening proxy protocol")
+		listener = &proxyproto.Listener{Listener: listener}
 	}
 
 	if args.cert != "" {


### PR DESCRIPTION
When using dumbproxy in combination with a reverse proxy server (particularly for SNI routing), [proxy protocol](https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt) support can be useful.

In this PR it is added using the https://github.com/pires/go-proxyproto library.

Operation has been tested on both regular and systemd activated sockets (including unix).

Appropriate additions were made to README.md