### PR TITLE
HTTP/2 upstream proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,17 @@ Supported proxy schemes are:
   * `curves` - colon-separated list of enabled TLS key exchange curves.
   * `min-tls-version` - minimum TLS version.
   * `max-tls-version` - maximum TLS version.
+* `h2` - HTTP/2 proxy over TLS connection. Examples: `h2://user:password@example.org`, `h2://example.org?cert=cert.pem&key=key.pem`. This method also supports additional parameters passed in query string:
+  * `cafile` - file with CA certificates in PEM format used to verify TLS peer.
+  * `sni` - override value of ServerName Indication extension.
+  * `peername` - expect specified name in peer certificate. Empty string relaxes any name constraints.
+  * `cert` - file with user certificate for mutual TLS authentication. Should be used in conjunction with `key`.
+  * `key` - file with private key matching user certificate specified with `cert` option.
+  * `ciphers` - colon-separated list of enabled TLS ciphersuites.
+  * `curves` - colon-separated list of enabled TLS key exchange curves.
+  * `min-tls-version` - minimum TLS version.
+  * `max-tls-version` - maximum TLS version.
+* `h2c` - HTTP/2 proxy over plaintext connection with the CONNECT method support. Examples: `h2c://example.org:8080`.
 * `socks5`, `socks5h` - SOCKS5 proxy with hostname resolving via remote proxy. Example: `socks5://127.0.0.1:9050`.
 * `set-src-hints` - not an actual proxy, but a signal to use different source IP address hints for this connection. It's useful to route traffic across multiple network interfaces, including VPN connections. URL has to have one query parameter `hints` with a comma-separated list of IP addresses. See `-ip-hints` command line option for more details. Example: `set-src-hints://?hints=10.2.0.2`
 * `cached` - pseudo-dialer which caches construction of another dialer specified by URL passed in `url` parameter of query string. Useful for dialers which are constructed dynamically from JS router script and which load certificate files. Example: `cache://?url=https%3A%2F%2Fexample.org%3Fcert%3Dcert.pem%26key%3Dkey.pem&ttl=5m`. Query string parameters are:

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -12,6 +12,8 @@ import (
 func init() {
 	xproxy.RegisterDialerType("http", HTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("https", HTTPProxyDialerFromURL)
+	xproxy.RegisterDialerType("h2", H2ProxyDialerFromURL)
+	xproxy.RegisterDialerType("h2c", H2ProxyDialerFromURL)
 	xproxy.RegisterDialerType("set-src-hints", NewHintsSettingDialerFromURL)
 	xproxy.RegisterDialerType("cached", GetCachedDialer)
 }

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -1,0 +1,171 @@
+package dialer
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/SenseUnit/dumbproxy/tlsutil"
+	"golang.org/x/net/http2"
+	xproxy "golang.org/x/net/proxy"
+)
+
+type H2ProxyDialer struct {
+	address   string
+	tlsConfig *tls.Config
+	userinfo  *url.Userinfo
+	next      Dialer
+	t         *http2.Transport
+}
+
+func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
+	host := u.Hostname()
+	port := u.Port()
+
+	var (
+		tlsConfig *tls.Config
+		err       error
+		h2c       bool
+	)
+	switch strings.ToLower(u.Scheme) {
+	case "h2c":
+		if port == "" {
+			port = "80"
+		}
+		h2c = true
+	case "h2":
+		if port == "" {
+			port = "443"
+		}
+		tlsConfig, err = tlsutil.TLSConfigFromURL(u)
+		if !slices.Contains(tlsConfig.NextProtos, "h2") {
+			tlsConfig.NextProtos = append([]string{"h2"}, tlsConfig.NextProtos...)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("TLS configuration failed: %w", err)
+		}
+	default:
+		return nil, errors.New("unsupported proxy type")
+	}
+
+	address := net.JoinHostPort(host, port)
+	t := &http2.Transport{
+		AllowHTTP:       h2c,
+		TLSClientConfig: tlsConfig,
+	}
+	nextDialer := MaybeWrapWithContextDialer(next)
+	if h2c {
+		t.DialTLSContext = func(ctx context.Context, network, _ string, _ *tls.Config) (net.Conn, error) {
+			return nextDialer.DialContext(ctx, network, address)
+		}
+	} else {
+		t.DialTLSContext = func(ctx context.Context, network, _ string, _ *tls.Config) (net.Conn, error) {
+			conn, err := nextDialer.DialContext(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+			conn = tls.Client(conn, tlsConfig)
+			return conn, nil
+		}
+	}
+
+	return &H2ProxyDialer{
+		address:   address,
+		tlsConfig: tlsConfig,
+		userinfo:  u.User,
+		next:      MaybeWrapWithContextDialer(next),
+		t:         t,
+	}, nil
+}
+
+func (d *H2ProxyDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *H2ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	h2c := d.tlsConfig == nil
+	scheme := "https"
+	if h2c {
+		scheme = "http"
+	}
+	pr, pw := io.Pipe()
+	req := &http.Request{
+		Method: "CONNECT",
+		URL: &url.URL{
+			Scheme: scheme,
+			Host:   address,
+		},
+		Header: http.Header{
+			"User-Agent": []string{"dumbproxy"},
+		},
+		Body: pr,
+		Host: address,
+	}
+	if d.userinfo != nil {
+		req.Header.Set("Proxy-Authorization", basicAuthHeader(d.userinfo))
+	}
+	resp, err := d.t.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		pw.Close()
+		return nil, errors.New(resp.Status)
+	}
+	return &h2Conn{
+		r: resp.Body,
+		w: pw,
+	}, nil
+}
+
+type h2Conn struct {
+	r io.Reader
+	w io.Writer
+}
+
+func (c *h2Conn) Read(b []byte) (n int, err error) {
+	return c.r.Read(b)
+}
+
+func (c *h2Conn) Write(b []byte) (n int, err error) {
+	return c.w.Write(b)
+}
+
+func (c *h2Conn) Close() (err error) {
+	if w, ok := c.w.(io.Closer); ok {
+		err = w.Close()
+	}
+	if r, ok := c.r.(io.Closer); ok {
+		err = r.Close()
+	}
+	return
+}
+
+func (c *h2Conn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4zero, Port: 0}
+}
+
+func (c *h2Conn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4zero, Port: 0}
+}
+
+func (c *h2Conn) SetDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "h2", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (c *h2Conn) SetReadDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "h2", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (c *h2Conn) SetWriteDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "h2", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -97,7 +97,7 @@ func (d *H2ProxyDialer) DialContext(ctx context.Context, network, address string
 		scheme = "http"
 	}
 	pr, pw := io.Pipe()
-	connCtx, connCl := context.WithCancel(context.Background())
+	connCtx, connCl := context.WithCancel(ctx)
 	req := (&http.Request{
 		Method: "CONNECT",
 		URL: &url.URL{

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -169,3 +169,7 @@ func (c *h2Conn) SetReadDeadline(t time.Time) error {
 func (c *h2Conn) SetWriteDeadline(t time.Time) error {
 	return &net.OpError{Op: "set", Net: "h2", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
 }
+
+func (c *h2Conn) CloseWrite() error {
+	return c.w.Close()
+}


### PR DESCRIPTION
Adds `h2://` and `h2c://` upstream proxy schemes.