### PR TITLE
Cleaned Dockerfile, switched to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,18 @@ ARG TARGETOS TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -tags netgo -ldflags '-s -w -extldflags "-static" -X main.version='"$GIT_DESC"
 RUN mkdir /.dumbproxy
 
-FROM scratch AS scratch
+FROM scratch
 COPY --from=build /go/src/github.com/SenseUnit/dumbproxy/dumbproxy /
 COPY --from=build --chown=9999:9999 /.dumbproxy /.dumbproxy
 USER 9999:9999
 EXPOSE 8080/tcp
-ENTRYPOINT ["/dumbproxy", "-bind-address", ":8080"]
+ENTRYPOINT ["/dumbproxy"]
+CMD ["-bind-address", ":8080" ]
 
-FROM alpine AS alpine
-COPY --from=build /go/src/github.com/SenseUnit/dumbproxy/dumbproxy /
-COPY --from=build --chown=9999:9999 /.dumbproxy /.dumbproxy
-RUN apk add --no-cache tzdata
-USER 9999:9999
-EXPOSE 8080/tcp
-ENTRYPOINT ["/dumbproxy", "-bind-address", ":8080"]
+#FROM alpine AS alpine
+#COPY --from=build /go/src/github.com/SenseUnit/dumbproxy/dumbproxy /
+#COPY --from=build --chown=9999:9999 /.dumbproxy /.dumbproxy
+#RUN apk add --no-cache tzdata
+#USER 9999:9999
+#EXPOSE 8080/tcp
+#ENTRYPOINT ["/dumbproxy", "-bind-address", ":8080"]


### PR DESCRIPTION
Minor cleanup of the Dockerfile

* Ensure that final build is happening as a scratch container, containing only `/dumbproxy` binary.
   (Also removing `AS scratch` which cause a syntax warning because its a reserved keyword.
   
* Switch to using a combination of `ENTRYPOINT` and `CMD`. This is more standard and allows running dumbproxy easily with different parameters.

    Examples are:
      `docker run -ti --rm dumbproxy -v`
      `docker run -ti --rm dumbproxy -passwd`
