### PR TITLE
External resolver integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Simple, scriptable, secure forward proxy.
     * Optional AEAD encryption layer for cache
 * Per-user bandwidth limits
 * HTTP/2 support, both server and client, including h2c support
-* Optional DNS cache
+* Advanced DNS support
+  * Plain DNS
+  * DNS-over-HTTPS
+  * DNS-over-TLS
+  * System-provided DNS
+  * Competitive parallel resolving using any of above
+  * Optional DNS cache
 * Resilient to DPI (including active probing, see `hidden_domain` option for authentication providers)
 * Connecting via upstream HTTP(S)/SOCKS5 proxies (proxy chaining)
   * Optional parroting of TLS fingerprints of popular software such as web browsers.
@@ -493,6 +499,10 @@ Usage of /home/user/go/bin/dumbproxy:
     	timeout for shared resolves of DNS cache (default 5s)
   -dns-cache-ttl duration
     	enable DNS cache with specified fixed TTL
+  -dns-prefer-address value
+    	address resolution preference (none/ipv4/ipv6) (default ipv4)
+  -dns-server value
+    	nameserver specification (udp://..., tcp://..., https://..., tls://..., doh://..., dot://..., default://). Option can be used multiple times for parallel use of multiple nameservers. Empty string resets the list
   -hmac-genkey
     	generate hex-encoded HMAC signing key of optimal length
   -hmac-sign

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/libp2p/go-reuseport v0.4.0
+	github.com/ncruces/go-dns v1.2.7
 	github.com/redis/go-redis/v9 v9.13.0
 	github.com/refraction-networking/utls v1.8.0
 	github.com/tg123/go-htpasswd v1.2.4
@@ -21,8 +22,6 @@ require (
 	golang.org/x/sync v0.16.0
 	golang.org/x/time v0.12.0
 )
-
-require github.com/ncruces/go-dns v1.2.7 // indirect
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	golang.org/x/time v0.12.0
 )
 
+require github.com/ncruces/go-dns v1.2.7 // indirect
+
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQscQm2s=
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
+github.com/ncruces/go-dns v1.2.7 h1:NMA7vFqXUl+nBhGFlleLyo2ni3Lqv3v+qFWZidzRemI=
+github.com/ncruces/go-dns v1.2.7/go.mod h1:SqmhVMBd8Wr7hsu3q6yTt6/Jno/xLMrbse/JLOMBo1Y=
 github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
 github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -362,7 +362,7 @@ func parse_args() CLIArgs {
 	flag.Int64Var(&args.bwBurst, "bw-limit-burst", 0, "allowed burst size for bandwidth limit, how many \"tokens\" can fit into leaky bucket")
 	flag.UintVar(&args.bwBuckets, "bw-limit-buckets", 1024*1024, "number of buckets of bandwidth limit")
 	flag.BoolVar(&args.bwSeparate, "bw-limit-separate", false, "separate upload and download bandwidth limits")
-	flag.Func("nameserver", "nameserver specification (udp://..., tcp://..., https://..., tls://..., doh://..., dot://...). Option can be used multiple times for parallel use of multiple nameservers. Empty string resets list", func(p string) error {
+	flag.Func("dns-server", "nameserver specification (udp://..., tcp://..., https://..., tls://..., doh://..., dot://..., default://). Option can be used multiple times for parallel use of multiple nameservers. Empty string resets list", func(p string) error {
 		if p == "" {
 			args.nameservers = nil
 		} else {

--- a/main.go
+++ b/main.go
@@ -383,7 +383,7 @@ func parse_args() CLIArgs {
 	flag.Int64Var(&args.bwBurst, "bw-limit-burst", 0, "allowed burst size for bandwidth limit, how many \"tokens\" can fit into leaky bucket")
 	flag.UintVar(&args.bwBuckets, "bw-limit-buckets", 1024*1024, "number of buckets of bandwidth limit")
 	flag.BoolVar(&args.bwSeparate, "bw-limit-separate", false, "separate upload and download bandwidth limits")
-	flag.Func("dns-server", "nameserver specification (udp://..., tcp://..., https://..., tls://..., doh://..., dot://..., default://). Option can be used multiple times for parallel use of multiple nameservers. Empty string resets list", func(p string) error {
+	flag.Func("dns-server", "nameserver specification (udp://..., tcp://..., https://..., tls://..., doh://..., dot://..., default://). Option can be used multiple times for parallel use of multiple nameservers. Empty string resets the list", func(p string) error {
 		if p == "" {
 			args.dnsServers = nil
 		} else {

--- a/resolver/factory.go
+++ b/resolver/factory.go
@@ -55,6 +55,8 @@ begin:
 		}
 		hp := net.JoinHostPort(host, port)
 		return dns.NewDoTResolver(hp, dns.DoTAddresses(hp))
+	case "default":
+		return net.DefaultResolver, nil
 	default:
 		return nil, errors.New("not implemented")
 	}

--- a/resolver/factory.go
+++ b/resolver/factory.go
@@ -1,0 +1,61 @@
+package resolver
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/ncruces/go-dns"
+)
+
+func FromURL(u string) (*net.Resolver, error) {
+begin:
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+	host := parsed.Hostname()
+	port := parsed.Port()
+	switch scheme := strings.ToLower(parsed.Scheme); scheme {
+	case "":
+		switch {
+		case strings.HasPrefix(u, "//"):
+			u = "dns:" + u
+		default:
+			u = "dns://" + u
+		}
+		goto begin
+	case "udp", "dns":
+		if port == "" {
+			port = "53"
+		}
+		return NewPlainResolver(net.JoinHostPort(host, port)), nil
+	case "tcp":
+		if port == "" {
+			port = "53"
+		}
+		return NewTCPResolver(net.JoinHostPort(host, port)), nil
+	case "http", "https", "doh":
+		if port == "" {
+			if scheme == "http" {
+				port = "80"
+			} else {
+				port = "443"
+			}
+		}
+		if scheme == "doh" {
+			parsed.Scheme = "https"
+			u = parsed.String()
+		}
+		return dns.NewDoHResolver(u, dns.DoHAddresses(net.JoinHostPort(host, port)))
+	case "tls", "dot":
+		if port == "" {
+			port = "853"
+		}
+		hp := net.JoinHostPort(host, port)
+		return dns.NewDoTResolver(hp, dns.DoTAddresses(hp))
+	default:
+		return nil, errors.New("not implemented")
+	}
+}

--- a/resolver/fast.go
+++ b/resolver/fast.go
@@ -1,0 +1,74 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+type LookupNetIPer interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+type FastResolver struct {
+	upstreams []LookupNetIPer
+}
+
+func FastFromURLs(urls ...string) (LookupNetIPer, error) {
+	resolvers := make([]LookupNetIPer, 0, len(urls))
+	for i, u := range urls {
+		res, err := FromURL(u)
+		if err != nil {
+			return nil, fmt.Errorf("unable to construct resolver #%d (%q): %w", i, u, err)
+		}
+		resolvers = append(resolvers, res)
+	}
+	if len(resolvers) == 1 {
+		return resolvers[0], nil
+	}
+	return NewFastResolver(resolvers...), nil
+}
+
+func NewFastResolver(resolvers ...LookupNetIPer) *FastResolver {
+	return &FastResolver{
+		upstreams: resolvers,
+	}
+}
+
+func (r FastResolver) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	ctx, cl := context.WithCancel(ctx)
+	defer cl()
+	errors := make(chan error)
+	success := make(chan []netip.Addr)
+	for _, res := range r.upstreams {
+		go func(res LookupNetIPer) {
+			addrs, err := res.LookupNetIP(ctx, network, host)
+			if err == nil {
+				select {
+				case success <- addrs:
+				case <-ctx.Done():
+				}
+			} else {
+				select {
+				case errors <- err:
+				case <-ctx.Done():
+				}
+			}
+		}(res)
+	}
+
+	var resErr error
+	for _ = range r.upstreams {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case resAddrs := <-success:
+			return resAddrs, nil
+		case err := <-errors:
+			resErr = multierror.Append(resErr, err)
+		}
+	}
+	return nil, resErr
+}

--- a/resolver/plain.go
+++ b/resolver/plain.go
@@ -1,0 +1,35 @@
+package resolver
+
+import (
+	"context"
+	"net"
+)
+
+func NewPlainResolver(addr string) *net.Resolver {
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{
+				Resolver: &net.Resolver{},
+			}).DialContext(ctx, network, addr)
+		},
+	}
+}
+
+func NewTCPResolver(addr string) *net.Resolver {
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			dnet := "tcp"
+			switch network {
+			case "udp4":
+				dnet = "tcp4"
+			case "udp6":
+				dnet = "tcp6"
+			}
+			return (&net.Dialer{
+				Resolver: &net.Resolver{},
+			}).DialContext(ctx, dnet, addr)
+		},
+	}
+}

--- a/resolver/prefer.go
+++ b/resolver/prefer.go
@@ -1,0 +1,101 @@
+package resolver
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+type Preference int
+
+const (
+	PreferenceNothing Preference = iota
+	PreferenceIPv4
+	PreferenceIPv6
+)
+
+func (p Preference) String() string {
+	switch p {
+	case PreferenceNothing:
+		return "none"
+	case PreferenceIPv4:
+		return "ipv4"
+	case PreferenceIPv6:
+		return "ipv6"
+	default:
+		return fmt.Sprintf("Preference(%d)", int(p))
+	}
+}
+
+func ParsePreference(p string) (Preference, error) {
+	var res Preference
+	switch lp := strings.ToLower(p); lp {
+	case "none", "nothing", "any", "anything":
+		res = PreferenceNothing
+	case "ipv4", "ip4", "v4", "4":
+		res = PreferenceIPv4
+	case "ipv6", "ip6", "v6", "6":
+		res = PreferenceIPv6
+	default:
+		return 0, fmt.Errorf("unknown preference specification %q", p)
+	}
+	return res, nil
+}
+
+func boolToInt(x bool) int {
+	if x {
+		return 0
+	}
+	return 1
+}
+
+type PreferIPv4 struct {
+	LookupNetIPer
+}
+
+func (p PreferIPv4) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	addrs, err := p.LookupNetIPer.LookupNetIP(ctx, network, host)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortStableFunc(addrs, func(a, b netip.Addr) int {
+		return cmp.Compare(
+			boolToInt(a.Unmap().Is4()),
+			boolToInt(b.Unmap().Is4()),
+		)
+	})
+	return addrs, nil
+}
+
+type PreferIPv6 struct {
+	LookupNetIPer
+}
+
+func (p PreferIPv6) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	addrs, err := p.LookupNetIPer.LookupNetIP(ctx, network, host)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortStableFunc(addrs, func(a, b netip.Addr) int {
+		return cmp.Compare(
+			boolToInt(a.Unmap().Is6()),
+			boolToInt(b.Unmap().Is6()),
+		)
+	})
+	return addrs, nil
+}
+
+func Prefer(resolver LookupNetIPer, p Preference) LookupNetIPer {
+	switch p {
+	case PreferenceNothing:
+		return resolver
+	case PreferenceIPv4:
+		return PreferIPv4{resolver}
+	case PreferenceIPv6:
+		return PreferIPv6{resolver}
+	}
+	panic("unknown address family preference")
+}


### PR DESCRIPTION
This PR introduces new option `nameserver` which allows to specify one or more nameservers used in parallel for all connections requiring the name resolution (generally ones which are not forwarded to some other upstream proxy-server).

Supported protocols:

- [x] Regular DNS (`dns://`, `udp://` or no protocol specification in URI at all).
- [x] DNS forced over TCP.
- [x] DNS over HTTPS (`doh://`, `https://`)
- [x] DNS over TLS (`dot://`, `tls://`)
- [x] Default system resolver (`default://`)
- [x] Some sort of IP family preference wrapper?