### PR TITLE
Support upstream SOCKS5 over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,17 @@ Supported proxy schemes are:
 * `h2c` - HTTP/2 proxy over plaintext connection with the CONNECT method support. Examples: `h2c://example.org:8080`.
   * `fetchrandom` - request server to send random data in the first request via every new HTTP/2 connection. Useful to trick TLS-in-TLS detection. Value format: length as a number or range `x-y`. Example: `fetchrandom=100000-500000`.
 * `socks5`, `socks5h` - SOCKS5 proxy with hostname resolving via remote proxy. Example: `socks5://127.0.0.1:9050`.
+* `socks5s`, `socks5hs` - SOCKS5 proxy over TLS with hostname resolving via remote proxy. Example: `socks5s://example.com:10443`. This method also supports additional parameters passed in query string:
+  * `cafile` - file with CA certificates in PEM format used to verify TLS peer.
+  * `sni` - override value of ServerName Indication extension.
+  * `peername` - expect specified name in peer certificate. Empty string relaxes any name constraints.
+  * `cert` - file with user certificate for mutual TLS authentication. Should be used in conjunction with `key`.
+  * `key` - file with private key matching user certificate specified with `cert` option.
+  * `ciphers` - colon-separated list of enabled TLS ciphersuites.
+  * `curves` - colon-separated list of enabled TLS key exchange curves.
+  * `min-tls-version` - minimum TLS version.
+  * `max-tls-version` - maximum TLS version.
+  * `utls-fp` - TLS fingerprint parroting with uTLS library. See the [list](https://pkg.go.dev/github.com/refraction-networking/utls#pkg-variables) of allowed client IDs. Example: `utls-fp=HelloChrome_Auto`.
 * `set-src-hints` - not an actual proxy, but a signal to use different source IP address hints for this connection. It's useful to route traffic across multiple network interfaces, including VPN connections. URL has to have one query parameter `hints` with a comma-separated list of IP addresses. See `-ip-hints` command line option for more details. Example: `set-src-hints://?hints=10.2.0.2`
 * `cached` - pseudo-dialer which caches construction of another dialer specified by URL passed in `url` parameter of query string. Useful for dialers which are constructed dynamically from JS router script and which load certificate files. Example: `cache://?url=https%3A%2F%2Fexample.org%3Fcert%3Dcert.pem%26key%3Dkey.pem&ttl=5m`. Query string parameters are:
    * `url` - actual proxy URL. Note that just like any query string parameter this one has to be URL-encoded to be passed as query string value.

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -22,6 +22,8 @@ func init() {
 	xproxy.RegisterDialerType("h2c", H2ProxyDialerFromURL)
 	xproxy.RegisterDialerType("set-src-hints", NewHintsSettingDialerFromURL)
 	xproxy.RegisterDialerType("cached", GetCachedDialer)
+	xproxy.RegisterDialerType("socks5s", SOCKS5SDialerFromURL)
+	xproxy.RegisterDialerType("socks5hs", SOCKS5SDialerFromURL)
 }
 
 type LegacyDialer interface {

--- a/dialer/socks5s.go
+++ b/dialer/socks5s.go
@@ -1,0 +1,57 @@
+package dialer
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/SenseUnit/dumbproxy/tlsutil"
+	xproxy "golang.org/x/net/proxy"
+)
+
+func SOCKS5SDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
+	var (
+		tlsConfig  *tls.Config
+		tlsFactory func(net.Conn, *tls.Config) net.Conn
+		err        error
+	)
+	tlsConfig, err = tlsutil.TLSConfigFromURL(u)
+	if err != nil {
+		return nil, fmt.Errorf("TLS configuration failed: %w", err)
+	}
+	tlsFactory, err = tlsutil.TLSFactoryFromURL(u)
+	if err != nil {
+		return nil, fmt.Errorf("TLS configuration failed: %w", err)
+	}
+	u.Scheme = "socks5"
+	u.RawQuery = ""
+	return xproxy.FromURL(u, NewTLSWrappingDialer(tlsConfig, tlsFactory, MaybeWrapWithContextDialer(next)))
+}
+
+type TLSWrappingDialer struct {
+	next       Dialer
+	tlsConfig  *tls.Config
+	tlsFactory func(net.Conn, *tls.Config) net.Conn
+}
+
+func NewTLSWrappingDialer(tlsConfig *tls.Config, tlsFactory func(net.Conn, *tls.Config) net.Conn, next Dialer) *TLSWrappingDialer {
+	return &TLSWrappingDialer{
+		next:       next,
+		tlsConfig:  tlsConfig,
+		tlsFactory: tlsFactory,
+	}
+}
+
+func (d *TLSWrappingDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *TLSWrappingDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := d.next.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	return d.tlsFactory(conn, d.tlsConfig), nil
+}


### PR DESCRIPTION
This PR adds `socks5s://` upstream proxy scheme to support SOCKS5 inside TLS proxy connection.