### PR TITLE
Improvement: HTTP/2 connections healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,9 +476,13 @@ Supported proxy schemes are:
   * `min-tls-version` - minimum TLS version.
   * `max-tls-version` - maximum TLS version.
   * `fetchrandom` - request server to send random data in the first request via every new HTTP/2 connection. Useful to trick TLS-in-TLS detection. Value format: length as a number or range `x-y`. Example: `fetchrandom=100000-500000`.
+  * `read-idle-timeout` - timeout after which a health check using a ping frame will be carried out if no frame is received on the connection. If zero, no health check is performed. Default: `5s`.
+  * `ping-timeout` - timeout after which the connection will be closed if a response to a ping is not received. Default: `5s`.
   * `utls-fp` - TLS fingerprint parroting with uTLS library. See the [list](https://pkg.go.dev/github.com/refraction-networking/utls#pkg-variables) of allowed client IDs. Example: `utls-fp=HelloChrome_Auto`.
 * `h2c` - HTTP/2 proxy over plaintext connection with the CONNECT method support. Examples: `h2c://example.org:8080`.
   * `fetchrandom` - request server to send random data in the first request via every new HTTP/2 connection. Useful to trick TLS-in-TLS detection. Value format: length as a number or range `x-y`. Example: `fetchrandom=100000-500000`.
+  * `read-idle-timeout` - timeout after which a health check using a ping frame will be carried out if no frame is received on the connection. If zero, no health check is performed. Default: `5s`.
+  * `ping-timeout` - timeout after which the connection will be closed if a response to a ping is not received. Default: `5s`.
 * `socks5`, `socks5h` - SOCKS5 proxy with hostname resolving via remote proxy. Example: `socks5://127.0.0.1:9050`.
 * `socks5s`, `socks5hs` - SOCKS5 proxy over TLS with hostname resolving via remote proxy. Example: `socks5s://example.com:10443`. This method also supports additional parameters passed in query string:
   * `cafile` - file with CA certificates in PEM format used to verify TLS peer.

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -89,15 +89,11 @@ func MaybeWrapWithContextDialer(d LegacyDialer) Dialer {
 	return wrappedDialer{d}
 }
 
-func garbageLenFuncFromURL(u *url.URL, paramname string) (func() int, error) {
-	params, err := url.ParseQuery(u.RawQuery)
-	if err != nil {
-		return nil, fmt.Errorf("garbage len param parse failed: %w", err)
-	}
-	if !params.Has(paramname) {
+func garbageLenFuncFromValues(params url.Values) (func() int, error) {
+	if !params.Has("fetchrandom") {
 		return nil, nil
 	}
-	left, right, found := strings.Cut(params.Get(paramname), "-")
+	left, right, found := strings.Cut(params.Get("fetchrandom"), "-")
 	if found {
 		lo, err := strconv.Atoi(left)
 		if err != nil {

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -73,9 +73,27 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 	if err != nil {
 		return nil, err
 	}
+	readIdleTimeout := 5 * time.Second
+	pingTimeout := 5 * time.Second
+	if params.Has("read-idle-timeout") {
+		d, err := time.ParseDuration(params.Get("read-idle-timeout"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse duration in \"read-idle-timeout\" option: %w", err)
+		}
+		readIdleTimeout = d
+	}
+	if params.Has("ping-timeout") {
+		d, err := time.ParseDuration(params.Get("ping-timeout"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse duration in \"ping-timeout\" option: %w", err)
+		}
+		pingTimeout = d
+	}
 	t := &http2.Transport{
 		AllowHTTP:       h2c,
 		TLSClientConfig: tlsConfig,
+		ReadIdleTimeout: readIdleTimeout,
+		PingTimeout:     pingTimeout,
 	}
 	t.ConnPool = &clientConnPool{
 		t: t,

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -30,11 +30,14 @@ type H2ProxyDialer struct {
 func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
 	host := u.Hostname()
 	port := u.Port()
+	params, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query string parse failed: %w", err)
+	}
 
 	var (
 		tlsConfig  *tls.Config
 		tlsFactory func(net.Conn, *tls.Config) net.Conn
-		err        error
 		h2c        bool
 		scheme     string
 	)
@@ -66,7 +69,7 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 	}
 
 	address := net.JoinHostPort(host, port)
-	garbageLenFunc, err := garbageLenFuncFromURL(u, "fetchrandom")
+	garbageLenFunc, err := garbageLenFuncFromValues(params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Purpose of proposed changes**

Better handling of stale multiplexed connections (useful when computer wakes from sleep and multiplexed connection is no longer valid on NAT box).

**Essential steps taken**

* Little refactoring of upstream proxy URL parsing.
* Introduce `read-idle-timeout` and `ping-timeout` options with 5 second default value, controlling respective options of H2 transport (and HTTP/2 connections derived from it).