### PR TITLE
Allow use of netcgo on Windows, Mac and Plan9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROGNAME = dumbproxy
 OUTSUFFIX = bin/$(PROGNAME)
-BUILDOPTS = -a -tags netgo -trimpath -asmflags -trimpath
+BUILDOPTS = -trimpath -asmflags -trimpath
 LDFLAGS = -ldflags '-s -w -extldflags "-static"'
 LDFLAGS_NATIVE = -ldflags '-s -w'
 


### PR DESCRIPTION
**Purpose of proposed changes**

Allow use of netcgo system DNS resolver on Windows, Mac and Plan9 in order to avoid DNS issues with netgo DNS resolver on these platforms.

**Essential steps taken**

Removed build tag disabling netcgo DNS resolver.
