### PR TITLE
JS dialer: explicit pre-flight property

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ It is possible to filter (allow or deny) requests with simple `access` JS functi
    * **originalHost** *(String)* - original hostname or IP address parsed from request.
    * **resolvedHost** *(String)* - resolved hostname from request or `null` if resolving was not performed (e.g. if upstream dialer is a proxy).
    * **port** *(Number)* - port number.
+   * **preview** *(Boolean)* - true, if this function invocation is made with unresolved destination address in order to determine upstream kind and if it needs resolving at all.
 3. **Username** *(String)*. Name of the authenticated user or an empty string if there is no authentication.
 
 `access` function must return boolean value, `true` allows request and `false` forbids it. Any exception will be reported to log and the corresponding request will be denied.

--- a/dialer/jsrouter.go
+++ b/dialer/jsrouter.go
@@ -81,13 +81,14 @@ func NewJSRouter(filename string, instances int, factory func(string) (Dialer, e
 	}, nil
 }
 
-func (j *JSRouter) getNextDialer(ctx context.Context, network, address string) (Dialer, error) {
+func (j *JSRouter) getNextDialer(ctx context.Context, network, address string, preview bool) (Dialer, error) {
 	req, username := dto.FilterParamsFromContext(ctx)
 	ri := jsext.JSRequestInfoFromRequest(req)
 	di, err := jsext.JSDstInfoFromContext(ctx, network, address)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct dst info: %w", err)
 	}
+	di.Preview = preview
 
 	var res string
 	func() {
@@ -113,7 +114,7 @@ func (j *JSRouter) getNextDialer(ctx context.Context, network, address string) (
 }
 
 func (j *JSRouter) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	d, err := j.getNextDialer(ctx, network, address)
+	d, err := j.getNextDialer(ctx, network, address, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to route request: %w", err)
 	}
@@ -121,7 +122,7 @@ func (j *JSRouter) DialContext(ctx context.Context, network, address string) (ne
 }
 
 func (j *JSRouter) WantsHostname(ctx context.Context, network, address string) bool {
-	d, err := j.getNextDialer(ctx, network, address)
+	d, err := j.getNextDialer(ctx, network, address, true)
 	if err != nil {
 		return false
 	}

--- a/jsext/dto.go
+++ b/jsext/dto.go
@@ -47,6 +47,7 @@ type JSDstInfo struct {
 	OriginalHost string  `json:"originalHost"`
 	ResolvedHost *string `json:"resolvedHost"`
 	Port         uint16  `json:"port"`
+	Preview      bool    `json:"preview"`
 }
 
 func JSDstInfoFromContext(ctx context.Context, network, address string) (*JSDstInfo, error) {


### PR DESCRIPTION
**Purpose of proposed changes**

Allow JS scripts to distinguish between pre-flight queries and actual dials.

**Essential steps taken**

Add explicit `preview` boolean property to destination information object.