### PR TITLE
Unified HTTPS upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,8 @@ Following objects are additionally available in global scope of JS scripts:
 Supported proxy schemes are:
 
 * `http` - regular HTTP proxy with the CONNECT method support. Examples: `http://example.org:3128`.
-* `https` - HTTP proxy over TLS connection. Examples: `https://user:password@example.org`, `https://example.org?cert=cert.pem&key=key.pem`. This method also supports additional parameters passed in query string:
+* `https` - HTTP proxy over TLS connection. Examples: `https://user:password@example.org`, `https://example.org?cert=cert.pem&key=key.pem`. This dialer is an opportunistic wrapper for `http1s` and `h2` proxy schemes, switching protocol automatically by ALPN during TLS handshake. It supports same options as underlying `http1s` and `h2` transports.
+* `http1s` - HTTP/1 proxy over TLS connection, forcing HTTP version. Options can be passed via query string:
   * `cafile` - file with CA certificates in PEM format used to verify TLS peer.
   * `sni` - override value of ServerName Indication extension.
   * `peername` - expect specified name in peer certificate. Empty string relaxes any name constraints.
@@ -468,8 +469,6 @@ Supported proxy schemes are:
   * `min-tls-version` - minimum TLS version.
   * `max-tls-version` - maximum TLS version.
   * `utls-fp` - TLS fingerprint parroting with uTLS library. See the [list](https://pkg.go.dev/github.com/refraction-networking/utls#pkg-variables) of allowed client IDs. Example: `utls-fp=HelloChrome_Auto`.
-* `http+optimistic` - (EXPERIMENTAL) HTTP proxy dialer which reads the connection success response asynchronously.
-* `https+optimistic` - (EXPERIMENTAL) HTTP proxy over TLS dialer which reads the connection success response asynchronously. Options are same as for `https` dialer.
 * `h2` - HTTP/2 proxy over TLS connection. Examples: `h2://user:password@example.org`, `h2://example.org?cert=cert.pem&key=key.pem`. This method also supports additional parameters passed in query string:
   * `cafile` - file with CA certificates in PEM format used to verify TLS peer.
   * `sni` - override value of ServerName Indication extension.
@@ -500,6 +499,8 @@ Supported proxy schemes are:
   * `min-tls-version` - minimum TLS version.
   * `max-tls-version` - maximum TLS version.
   * `utls-fp` - TLS fingerprint parroting with uTLS library. See the [list](https://pkg.go.dev/github.com/refraction-networking/utls#pkg-variables) of allowed client IDs. Example: `utls-fp=HelloChrome_Auto`.
+* `http+optimistic` - (EXPERIMENTAL) HTTP/1 proxy dialer which reads the connection success response asynchronously.
+* `https+optimistic` - (EXPERIMENTAL) HTTP/1 proxy over TLS dialer which reads the connection success response asynchronously. Options are same as for `http1s` dialer.
 * `set-src-hints` - not an actual proxy, but a signal to use different source IP address hints for this connection. It's useful to route traffic across multiple network interfaces, including VPN connections. URL has to have one query parameter `hints` with a comma-separated list of IP addresses. See `-ip-hints` command line option for more details. Example: `set-src-hints://?hints=10.2.0.2`
 * `cached` - pseudo-dialer which caches construction of another dialer specified by URL passed in `url` parameter of query string. Useful for dialers which are constructed dynamically from JS router script and which load certificate files. Example: `cached://?url=https%3A%2F%2Fexample.org%3Fcert%3Dcert.pem%26key%3Dkey.pem&ttl=5m`. Query string parameters are:
    * `url` - actual proxy URL. Note that just like any query string parameter this one has to be URL-encoded to be passed as query string value.

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	xproxy.RegisterDialerType("http", H1ProxyDialerFromURL)
 	xproxy.RegisterDialerType("http1s", H1ProxyDialerFromURL)
+	xproxy.RegisterDialerType("https", UnifiedHTTPSProxyDialerFromURL)
 	xproxy.RegisterDialerType("http+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("https+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("h2", H2ProxyDialerFromURL)

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	xproxy.RegisterDialerType("http", H1ProxyDialerFromURL)
-	xproxy.RegisterDialerType("https", H1ProxyDialerFromURL)
+	xproxy.RegisterDialerType("http1s", H1ProxyDialerFromURL)
 	xproxy.RegisterDialerType("http+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("https+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("h2", H2ProxyDialerFromURL)

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -14,8 +14,8 @@ import (
 )
 
 func init() {
-	xproxy.RegisterDialerType("http", HTTPProxyDialerFromURL)
-	xproxy.RegisterDialerType("https", HTTPProxyDialerFromURL)
+	xproxy.RegisterDialerType("http", H1ProxyDialerFromURL)
+	xproxy.RegisterDialerType("https", H1ProxyDialerFromURL)
 	xproxy.RegisterDialerType("http+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("https+optimistic", OptimisticHTTPProxyDialerFromURL)
 	xproxy.RegisterDialerType("h2", H2ProxyDialerFromURL)

--- a/dialer/h1.go
+++ b/dialer/h1.go
@@ -20,7 +20,7 @@ import (
 	"github.com/SenseUnit/dumbproxy/tlsutil"
 )
 
-type HTTPProxyDialer struct {
+type H1ProxyDialer struct {
 	address    string
 	tlsConfig  *tls.Config
 	tlsFactory func(net.Conn, *tls.Config) net.Conn
@@ -28,8 +28,8 @@ type HTTPProxyDialer struct {
 	next       Dialer
 }
 
-func NewHTTPProxyDialer(address string, tlsConfig *tls.Config, userinfo *url.Userinfo, next LegacyDialer) *HTTPProxyDialer {
-	return &HTTPProxyDialer{
+func NewH1ProxyDialer(address string, tlsConfig *tls.Config, userinfo *url.Userinfo, next LegacyDialer) *H1ProxyDialer {
+	return &H1ProxyDialer{
 		address:   address,
 		tlsConfig: tlsConfig,
 		next:      MaybeWrapWithContextDialer(next),
@@ -37,7 +37,7 @@ func NewHTTPProxyDialer(address string, tlsConfig *tls.Config, userinfo *url.Use
 	}
 }
 
-func HTTPProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
+func H1ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
 	host := u.Hostname()
 	port := u.Port()
 
@@ -69,7 +69,7 @@ func HTTPProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, erro
 
 	address := net.JoinHostPort(host, port)
 
-	return &HTTPProxyDialer{
+	return &H1ProxyDialer{
 		address:    address,
 		tlsConfig:  tlsConfig,
 		tlsFactory: tlsFactory,
@@ -78,11 +78,11 @@ func HTTPProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, erro
 	}, nil
 }
 
-func (d *HTTPProxyDialer) Dial(network, address string) (net.Conn, error) {
+func (d *H1ProxyDialer) Dial(network, address string) (net.Conn, error) {
 	return d.DialContext(context.Background(), network, address)
 }
 
-func (d *HTTPProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (d *H1ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 	default:

--- a/dialer/h1.go
+++ b/dialer/h1.go
@@ -51,7 +51,7 @@ func H1ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 		if port == "" {
 			port = "80"
 		}
-	case "https":
+	case "https", "http1s":
 		if port == "" {
 			port = "443"
 		}

--- a/dialer/h1.go
+++ b/dialer/h1.go
@@ -83,17 +83,25 @@ func (d *H1ProxyDialer) Dial(network, address string) (net.Conn, error) {
 }
 
 func (d *H1ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	switch network {
-	case "tcp", "tcp4", "tcp6":
-	default:
-		return nil, errors.New("only \"tcp\" network is supported")
-	}
-	conn, err := d.next.DialContext(ctx, "tcp", d.address)
-	if err != nil {
-		return nil, fmt.Errorf("proxy dialer is unable to make connection: %w", err)
-	}
-	if d.tlsConfig != nil {
-		conn = d.tlsFactory(conn, d.tlsConfig)
+	var (
+		conn net.Conn
+		err  error
+	)
+	if rc := redeemedConnFromContext(ctx); rc != nil {
+		conn = rc
+	} else {
+		switch network {
+		case "tcp", "tcp4", "tcp6":
+		default:
+			return nil, errors.New("only \"tcp\" network is supported")
+		}
+		conn, err = d.next.DialContext(ctx, "tcp", d.address)
+		if err != nil {
+			return nil, fmt.Errorf("proxy dialer is unable to make connection: %w", err)
+		}
+		if d.tlsConfig != nil {
+			conn = d.tlsFactory(conn, d.tlsConfig)
+		}
 	}
 
 	stopGuardEvent := make(chan struct{})
@@ -177,4 +185,17 @@ func basicAuthHeader(userinfo *url.Userinfo) string {
 	password, _ := userinfo.Password()
 	return "Basic " + base64.StdEncoding.EncodeToString(
 		[]byte(username+":"+password))
+}
+
+type redeemedConnKey struct{}
+
+func redeemedConnToContext(ctx context.Context, conn net.Conn) context.Context {
+	return context.WithValue(ctx, redeemedConnKey{}, conn)
+}
+
+func redeemedConnFromContext(ctx context.Context) net.Conn {
+	if conn, ok := ctx.Value(redeemedConnKey{}).(net.Conn); ok {
+		return conn
+	}
+	return nil
 }

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -181,7 +181,8 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 			h1Fallback := h1FallbackFromContext(ctx)
 			if h1Fallback && !slices.Contains(ctc.NextProtos, "http/1.1") {
 				ctc = ctc.Clone()
-				ctc.NextProtos = append(ctc.NextProtos, "http/1.1")
+				// don't touch array backing NextProtos slice of original cfg
+				ctc.NextProtos = append(ctc.NextProtos[0:len(ctc.NextProtos):len(ctc.NextProtos)], "http/1.1")
 			}
 			conn = tlsFactory(conn, ctc)
 			if tlsConn, ok := conn.(*tls.Conn); ok {

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -19,6 +19,24 @@ import (
 	xproxy "golang.org/x/net/proxy"
 )
 
+type h1RedeemError struct {
+	conn *tls.Conn
+}
+
+func (re h1RedeemError) Error() string {
+	return "HTTP/2 was not negotiated via ALPN"
+}
+
+func (re h1RedeemError) Close() error {
+	if re.conn != nil {
+		return re.conn.Close()
+	}
+	return nil
+}
+
+var _ error = h1RedeemError{}
+var _ io.Closer = h1RedeemError{}
+
 type H2ProxyDialer struct {
 	address   string
 	tlsConfig *tls.Config
@@ -55,6 +73,9 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 		tlsConfig, err = tlsutil.TLSConfigFromURL(u)
 		if !slices.Contains(tlsConfig.NextProtos, "h2") {
 			tlsConfig.NextProtos = append([]string{"h2"}, tlsConfig.NextProtos...)
+		}
+		if !slices.Contains(tlsConfig.NextProtos, "http/1.1") {
+			tlsConfig.NextProtos = append(tlsConfig.NextProtos, "http/1.1")
 		}
 		if err != nil {
 			return nil, fmt.Errorf("TLS configuration failed: %w", err)
@@ -147,6 +168,18 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 				return nil, err
 			}
 			conn = tlsFactory(conn, tlsConfig)
+			if tlsConn, ok := conn.(*tls.Conn); ok {
+				// it's a crypto/tls connection, we ought to see how ALPN went
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					tlsConn.Close()
+					return nil, err
+				}
+				if tlsConn.ConnectionState().NegotiatedProtocol != "h2" {
+					// HTTP/2 was NOT negotiated! abort, but save the connection
+					// for potential redemption via HTTP/1 dialer
+					return nil, h1RedeemError{tlsConn}
+				}
+			}
 			return conn, nil
 		}
 	}

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -23,8 +23,10 @@ type h1RedeemError struct {
 	conn *tls.Conn
 }
 
+const alpnNegErrorText = "HTTP/2 was not negotiated via ALPN"
+
 func (re h1RedeemError) Error() string {
-	return "HTTP/2 was not negotiated via ALPN"
+	return alpnNegErrorText
 }
 
 func (re h1RedeemError) Close() error {
@@ -36,6 +38,17 @@ func (re h1RedeemError) Close() error {
 
 var _ error = h1RedeemError{}
 var _ io.Closer = h1RedeemError{}
+
+type h1FallbackKey struct{}
+
+func h1FallbackToContext(ctx context.Context, value bool) context.Context {
+	return context.WithValue(ctx, h1FallbackKey{}, value)
+}
+
+func h1FallbackFromContext(ctx context.Context) bool {
+	h1Fallback, _ := ctx.Value(h1FallbackKey{}).(bool)
+	return h1Fallback
+}
 
 type H2ProxyDialer struct {
 	address   string
@@ -71,14 +84,11 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 			port = "443"
 		}
 		tlsConfig, err = tlsutil.TLSConfigFromURL(u)
-		if !slices.Contains(tlsConfig.NextProtos, "h2") {
-			tlsConfig.NextProtos = append([]string{"h2"}, tlsConfig.NextProtos...)
-		}
-		if !slices.Contains(tlsConfig.NextProtos, "http/1.1") {
-			tlsConfig.NextProtos = append(tlsConfig.NextProtos, "http/1.1")
-		}
 		if err != nil {
 			return nil, fmt.Errorf("TLS configuration failed: %w", err)
+		}
+		if !slices.Contains(tlsConfig.NextProtos, "h2") {
+			tlsConfig.NextProtos = append([]string{"h2"}, tlsConfig.NextProtos...)
 		}
 		tlsFactory, err = tlsutil.TLSFactoryFromURL(u)
 		if err != nil {
@@ -167,7 +177,13 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 			if err != nil {
 				return nil, err
 			}
-			conn = tlsFactory(conn, tlsConfig)
+			ctc := tlsConfig
+			h1Fallback := h1FallbackFromContext(ctx)
+			if h1Fallback && !slices.Contains(ctc.NextProtos, "http/1.1") {
+				ctc = ctc.Clone()
+				ctc.NextProtos = append(ctc.NextProtos, "http/1.1")
+			}
+			conn = tlsFactory(conn, ctc)
 			if tlsConn, ok := conn.(*tls.Conn); ok {
 				// it's a crypto/tls connection, we ought to see how ALPN went
 				if err := tlsConn.HandshakeContext(ctx); err != nil {
@@ -175,9 +191,13 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 					return nil, err
 				}
 				if tlsConn.ConnectionState().NegotiatedProtocol != "h2" {
-					// HTTP/2 was NOT negotiated! abort, but save the connection
-					// for potential redemption via HTTP/1 dialer
-					return nil, h1RedeemError{tlsConn}
+					if h1Fallback {
+						// HTTP/2 was NOT negotiated! abort, but save the connection
+						// for potential redemption via HTTP/1 dialer
+						return nil, h1RedeemError{tlsConn}
+					} else {
+						return nil, errors.New(alpnNegErrorText)
+					}
 				}
 			}
 			return conn, nil

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -196,6 +196,7 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 						// for potential redemption via HTTP/1 dialer
 						return nil, h1RedeemError{tlsConn}
 					} else {
+						tlsConn.Close()
 						return nil, errors.New(alpnNegErrorText)
 					}
 				}

--- a/dialer/h2.go
+++ b/dialer/h2.go
@@ -48,7 +48,7 @@ func H2ProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error)
 		}
 		h2c = true
 		scheme = "http"
-	case "h2":
+	case "h2", "https":
 		if port == "" {
 			port = "443"
 		}

--- a/dialer/unihttp.go
+++ b/dialer/unihttp.go
@@ -1,0 +1,51 @@
+package dialer
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+
+	xproxy "golang.org/x/net/proxy"
+)
+
+type UnifiedHTTPSProxyDialer struct {
+	h2dialer Dialer
+	h1dialer Dialer
+}
+
+func UnifiedHTTPSProxyDialerFromURL(u *url.URL, d xproxy.Dialer) (xproxy.Dialer, error) {
+	h2, err := H2ProxyDialerFromURL(u, d)
+	if err != nil {
+		return nil, err
+	}
+	h1, err := H1ProxyDialerFromURL(u, d)
+	if err != nil {
+		return nil, err
+	}
+	return &UnifiedHTTPSProxyDialer{
+		h2dialer: MaybeWrapWithContextDialer(h2),
+		h1dialer: MaybeWrapWithContextDialer(h1),
+	}, nil
+}
+
+func (d *UnifiedHTTPSProxyDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *UnifiedHTTPSProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := d.h2dialer.DialContext(ctx, network, address)
+	if err != nil {
+		if rerr, ok := errors.AsType[h1RedeemError](err); ok {
+			// we've got a connection, but need it's HTTP/1
+			ctx = redeemedConnToContext(ctx, rerr.conn)
+			conn, err := d.h1dialer.DialContext(ctx, network, address)
+			if err != nil {
+				// early cleanup
+				rerr.Close()
+			}
+			return conn, err
+		}
+	}
+	return conn, err
+}

--- a/dialer/unihttp.go
+++ b/dialer/unihttp.go
@@ -34,7 +34,7 @@ func (d *UnifiedHTTPSProxyDialer) Dial(network, address string) (net.Conn, error
 }
 
 func (d *UnifiedHTTPSProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	conn, err := d.h2dialer.DialContext(ctx, network, address)
+	conn, err := d.h2dialer.DialContext(h1FallbackToContext(ctx, true), network, address)
 	if err != nil {
 		if rerr, ok := errors.AsType[h1RedeemError](err); ok {
 			// we've got a connection, but need it's HTTP/1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SenseUnit/dumbproxy
 
-go 1.25.0
+go 1.26.0
 
 require (
 	codeberg.org/yarmak/secache v0.2.4


### PR DESCRIPTION
**Purpose of proposed changes**

Provide best performance and experience for users, negotiate best protocol with the proxy server automatically.

**Essential steps taken**

Implemented unified HTTPS dialer which invokes h2 dialer first and then passes estableshed TLS connection to HTTP/1 dialer if HTTP/2 was not negotiated. Old `https` dialer is now known as `http1s` dialer.

TODO:

- [x] Select ALPN being sent based on whether we expect h1 redemption.
- [x] Close redeemed connections early when they are not picked up by unified HTTPS handler (e.g. when we instantiate a dialer `h2://` with forced HTTP version).
- [x] Bump Go version to 1.26, we use errors.AsType now.
- [x] Never modify ALPN proto array of base TLS config of h2 dialer.
