### PR TITLE
Clean out legacy syntax

### DIFF
--- a/auth/cert_test.go
+++ b/auth/cert_test.go
@@ -10,7 +10,7 @@ import (
 
 func mkbytes(l uint) []byte {
 	b := make([]byte, l)
-	for i := uint(0); i < l; i++ {
+	for i := range l {
 		b[i] = byte(i)
 	}
 	return b

--- a/dialer/h2_client_conn_pool.go
+++ b/dialer/h2_client_conn_pool.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 
 	"golang.org/x/net/http/httpguts"
@@ -44,21 +45,12 @@ func isConnectionCloseRequest(req *http.Request) bool {
 	return req.Close || httpguts.HeaderValuesContainsToken(req.Header["Connection"], "close")
 }
 
-func strSliceContains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
 func (p *clientConnPool) newTLSConfig(host string) *tls.Config {
 	cfg := new(tls.Config)
 	if p.t.TLSClientConfig != nil {
 		*cfg = *p.t.TLSClientConfig.Clone()
 	}
-	if !strSliceContains(cfg.NextProtos, http2.NextProtoTLS) {
+	if !slices.Contains(cfg.NextProtos, http2.NextProtoTLS) {
 		cfg.NextProtos = append([]string{http2.NextProtoTLS}, cfg.NextProtos...)
 	}
 	if cfg.ServerName == "" {
@@ -259,10 +251,8 @@ func (c *addConnCall) run(t *http2.Transport, key string, nc net.Conn) {
 
 // p.mu must be held
 func (p *clientConnPool) addConnLocked(key string, cc *http2.ClientConn) {
-	for _, v := range p.conns {
-		if v == cc {
-			return
-		}
+	if slices.Contains(p.conns, cc) {
+		return
 	}
 	p.conns = append(p.conns, cc)
 }

--- a/dialer/hintdialer.go
+++ b/dialer/hintdialer.go
@@ -156,7 +156,7 @@ func ipToLAddr(network string, ip net.IP) (net.Addr, string, error) {
 
 func parseIPList(list string) ([]net.IP, error) {
 	res := make([]net.IP, 0)
-	for _, elem := range strings.Split(list, ",") {
+	for elem := range strings.SplitSeq(list, ",") {
 		elem = strings.TrimSpace(elem)
 		if len(elem) == 0 {
 			continue

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -127,7 +127,7 @@ func (s *ProxyHandler) HandleTunnel(wr http.ResponseWriter, req *http.Request, u
 				req.Context(),
 				username,
 				wrapPendingWrite(
-					[]byte(fmt.Sprintf("HTTP/%d.%d 200 OK\r\n\r\n", req.ProtoMajor, req.ProtoMinor)),
+					fmt.Appendf(nil, "HTTP/%d.%d 200 OK\r\n\r\n", req.ProtoMajor, req.ProtoMinor),
 					localconn,
 				),
 				conn,

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -36,7 +36,7 @@ func delHopHeaders(header http.Header) {
 	}
 }
 
-func hijack(hijackable interface{}) (net.Conn, *bufio.ReadWriter, error) {
+func hijack(hijackable any) (net.Conn, *bufio.ReadWriter, error) {
 	hj, ok := hijackable.(http.Hijacker)
 	if !ok {
 		return nil, nil, errors.New("Connection doesn't support hijacking")
@@ -54,7 +54,7 @@ func hijack(hijackable interface{}) (net.Conn, *bufio.ReadWriter, error) {
 	return conn, rw, nil
 }
 
-func flush(flusher interface{}) bool {
+func flush(flusher any) bool {
 	f, ok := flusher.(http.Flusher)
 	if !ok {
 		return false

--- a/jsext/printer.go
+++ b/jsext/printer.go
@@ -10,7 +10,7 @@ import (
 
 func AddPrinter(vm *goja.Runtime, logger *clog.CondLogger) error {
 	return vm.GlobalObject().Set("print", func(call goja.FunctionCall) goja.Value {
-		printArgs := make([]interface{}, len(call.Arguments))
+		printArgs := make([]any, len(call.Arguments))
 		for i, arg := range call.Arguments {
 			printArgs[i] = arg
 		}

--- a/log/condlog.go
+++ b/log/condlog.go
@@ -19,37 +19,37 @@ type CondLogger struct {
 	verbosity int
 }
 
-func (cl *CondLogger) Log(verb int, format string, v ...interface{}) error {
+func (cl *CondLogger) Log(verb int, format string, v ...any) error {
 	if verb >= cl.verbosity {
 		return cl.logger.Output(2, fmt.Sprintf(format, v...))
 	}
 	return nil
 }
 
-func (cl *CondLogger) log(verb int, format string, v ...interface{}) error {
+func (cl *CondLogger) log(verb int, format string, v ...any) error {
 	if verb >= cl.verbosity {
 		return cl.logger.Output(3, fmt.Sprintf(format, v...))
 	}
 	return nil
 }
 
-func (cl *CondLogger) Critical(s string, v ...interface{}) error {
+func (cl *CondLogger) Critical(s string, v ...any) error {
 	return cl.log(CRITICAL, "CRITICAL "+s, v...)
 }
 
-func (cl *CondLogger) Error(s string, v ...interface{}) error {
+func (cl *CondLogger) Error(s string, v ...any) error {
 	return cl.log(ERROR, "ERROR    "+s, v...)
 }
 
-func (cl *CondLogger) Warning(s string, v ...interface{}) error {
+func (cl *CondLogger) Warning(s string, v ...any) error {
 	return cl.log(WARNING, "WARNING  "+s, v...)
 }
 
-func (cl *CondLogger) Info(s string, v ...interface{}) error {
+func (cl *CondLogger) Info(s string, v ...any) error {
 	return cl.log(INFO, "INFO     "+s, v...)
 }
 
-func (cl *CondLogger) Debug(s string, v ...interface{}) error {
+func (cl *CondLogger) Debug(s string, v ...any) error {
 	return cl.log(DEBUG, "DEBUG    "+s, v...)
 }
 

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -254,7 +254,7 @@ func TestSimultaneousRequests(t *testing.T) {
 	}
 
 	wg.Add(numRequests)
-	for i := 0; i < numRequests; i++ {
+	for range numRequests {
 		go f()
 	}
 	wg.Wait()

--- a/tlsutil/ccache.go
+++ b/tlsutil/ccache.go
@@ -226,55 +226,55 @@ type bboltLogger struct {
 	l *clog.CondLogger
 }
 
-func (l bboltLogger) Debug(v ...interface{}) {
+func (l bboltLogger) Debug(v ...any) {
 	l.l.Debug("%s", fmt.Sprint(v...))
 }
 
-func (l bboltLogger) Debugf(format string, v ...interface{}) {
+func (l bboltLogger) Debugf(format string, v ...any) {
 	l.l.Debug(format, v...)
 }
 
-func (l bboltLogger) Error(v ...interface{}) {
+func (l bboltLogger) Error(v ...any) {
 	l.l.Error("%s", fmt.Sprint(v...))
 }
 
-func (l bboltLogger) Errorf(format string, v ...interface{}) {
+func (l bboltLogger) Errorf(format string, v ...any) {
 	l.l.Error(format, v...)
 }
 
-func (l bboltLogger) Info(v ...interface{}) {
+func (l bboltLogger) Info(v ...any) {
 	l.l.Info("%s", fmt.Sprint(v...))
 }
 
-func (l bboltLogger) Infof(format string, v ...interface{}) {
+func (l bboltLogger) Infof(format string, v ...any) {
 	l.l.Info(format, v...)
 }
 
-func (l bboltLogger) Warning(v ...interface{}) {
+func (l bboltLogger) Warning(v ...any) {
 	l.l.Warning("%s", fmt.Sprint(v...))
 }
 
-func (l bboltLogger) Warningf(format string, v ...interface{}) {
+func (l bboltLogger) Warningf(format string, v ...any) {
 	l.l.Warning(format, v...)
 }
 
-func (l bboltLogger) Fatal(v ...interface{}) {
+func (l bboltLogger) Fatal(v ...any) {
 	l.l.Critical("%s", fmt.Sprint(v...))
 	os.Exit(1)
 }
 
-func (l bboltLogger) Fatalf(format string, v ...interface{}) {
+func (l bboltLogger) Fatalf(format string, v ...any) {
 	l.l.Critical(format, v...)
 	os.Exit(1)
 }
 
-func (l bboltLogger) Panic(v ...interface{}) {
+func (l bboltLogger) Panic(v ...any) {
 	s := fmt.Sprint(v...)
 	l.l.Critical("%s", s)
 	panic(s)
 }
 
-func (l bboltLogger) Panicf(format string, v ...interface{}) {
+func (l bboltLogger) Panicf(format string, v ...any) {
 	s := fmt.Sprintf(format, v...)
 	l.l.Critical("%s", s)
 	panic(s)


### PR DESCRIPTION
**Purpose of proposed changes**

Get rid of legacy of old go versions, use more expressive modern syntax and routines.

**Essential steps taken**

`go fix ./...` and a little bit of manual removal.